### PR TITLE
biopython 1.77 dropped python 2 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ setup(
         "gdmodule>0.58",
         "Pillow",
         "matplotlib",
-        "biopython"],
+        "biopython<1.77"],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Make compatible with python 2 installation. Biopython now have 1.79 version that do not support python2 and therefore installing isoSegmenter throws error.